### PR TITLE
Android 9 support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       android:versionCode="4"
+      android:targetSandboxVersion="1"
       android:versionName="0.1.3alpha" package="com.simonramstedt.yoke">
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.INTERNET"/>
@@ -13,6 +14,7 @@
                  android:label="@string/app_name"
                  android:supportsRtl="true"
                  android:allowBackup="true"
+                 android:usesCleartextTraffic="true"
                  android:theme="@style/YokeTheme">
         <activity android:name=".YokeActivity"
                   android:label="@string/app_name"


### PR DESCRIPTION
Android 9 requires a couple of extra lines to the application manifest to allow connections to plain http servers, as described [here](https://stackoverflow.com/questions/45940861/android-8-cleartext-http-traffic-not-permitted)