### PR TITLE
Send binary data and small improvements.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.application'
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId 'com.simonramstedt.yoke'
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 android {
     compileSdkVersion 28
-    buildToolsVersion '28.0.3'
     defaultConfig {
         applicationId 'com.simonramstedt.yoke'
         minSdkVersion 21

--- a/app/src/main/java/com/simonramstedt/yoke/YokeActivity.java
+++ b/app/src/main/java/com/simonramstedt/yoke/YokeActivity.java
@@ -156,7 +156,7 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
 
         private final long INDETERMINATE = -1L;
         private final long DETERMINATE = -2L;
-        private final long SUCCESS = -4L;
+        private final long OVER = -4L;
 
         private final int MAX_PROGRESS = 1000;
 
@@ -245,12 +245,15 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
                 } else {
                     logError(e.getLocalizedMessage(), e);
                 }
+                publishProgress(0L, OVER);
                 cancel(true);
             } catch (JSONException e) {
                 logError(String.format(res.getString(R.string.error_json_exception), e.getLocalizedMessage()), e);
+                publishProgress(0L, OVER);
                 cancel(true);
             } catch (SecurityException e) {
                 logError(res.getString(R.string.error_security_exception), e);
+                publishProgress(0L, OVER);
                 cancel(true);
             }
             return null;
@@ -259,13 +262,16 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
         protected void onProgressUpdate(Long... progress) {
             if (progress[1] == INDETERMINATE) {
                 mProgressBar.setIndeterminate(true);
+                mProgressBar.setVisibility(View.VISIBLE);
             } else if (progress[1] == DETERMINATE) {
                 mProgressBar.setIndeterminate(false);
                 mProgressBar.setProgress(0);
                 mProgressBar.setMax((int)MAX_PROGRESS);
-            } else if (progress[1] == SUCCESS) {
+                mProgressBar.setVisibility(View.VISIBLE);
+            } else if (progress[1] == OVER) {
                 mProgressBar.setIndeterminate(false);
                 mProgressBar.setProgress(0);
+                mProgressBar.setVisibility(View.INVISIBLE);
                 Toast.makeText(YokeActivity.this, res.getString(R.string.toast_layout_succesfully_upgraded), Toast.LENGTH_LONG).show();
             } else {
                 mProgressBar.setProgress((int)(progress[0]*MAX_PROGRESS/progress[1]));
@@ -286,7 +292,7 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
                 logError(String.format(res.getString(R.string.error_io_exception), e.getLocalizedMessage()), e);
                 cancel(true);
             }
-            (new Thread(()-> publishProgress(0L, SUCCESS))).start();
+            (new Thread(()-> publishProgress(0L, OVER))).start();
         }
 
         @Override

--- a/app/src/main/java/com/simonramstedt/yoke/YokeActivity.java
+++ b/app/src/main/java/com/simonramstedt/yoke/YokeActivity.java
@@ -338,7 +338,7 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
                     wv.loadUrl(url);
                 } else {
                     logInfo(String.format(
-                        res.getString(R.string.toast_download_layout_first),
+                        res.getString(R.string.info_download_layout_first),
                         res.getString(R.string.menu_upgrade_layout),
                         res.getString(R.string.toolbar_reconnect)
                     ));
@@ -455,8 +455,7 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
                             mTextView.setText(res.getString(R.string.toolbar_connect_to));
                             mSpinner.setSelection(mAdapter.getPosition(NOTHING));
                             currentHost = null;
-                            Toast.makeText(YokeActivity.this, res.getString(R.string.toast_invalid_address), Toast.LENGTH_LONG).show();
-
+                            logInfo(res.getString(R.string.info_invalid_address));
                         } else {
                             mServiceNames.add(name);
                             mAdapter.add(name);
@@ -602,7 +601,7 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
     public void reconnect(View view) {
         String tgt = mSpinner.getSelectedItem().toString();
         if (currentHost == null) {
-            Toast.makeText(YokeActivity.this, res.getString(R.string.toast_connected_to_nowhere), Toast.LENGTH_LONG).show();
+            logInfo(res.getString(R.string.info_connected_to_nowhere));
         } else {
             log(res.getString(R.string.log_udp_closed));
             mSocket.close();
@@ -625,9 +624,7 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
                                 "http://" + currentHost + ":" + Integer.toString(currentPort) + "/"
                             );
                         } else {
-                            Toast.makeText(YokeActivity.this,
-                                res.getString(R.string.toast_connected_to_nowhere), Toast.LENGTH_LONG
-                            ).show();
+                            logInfo(res.getString(R.string.info_connected_to_nowhere));
                         }
                         return true;
                     default:

--- a/app/src/main/java/com/simonramstedt/yoke/YokeActivity.java
+++ b/app/src/main/java/com/simonramstedt/yoke/YokeActivity.java
@@ -149,6 +149,18 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
             vals_buffer = vals.getBytes(Charset.forName("ISO-8859-1"));
             update();
         }
+        @JavascriptInterface
+        public void alert(String m) {
+            AlertDialog.Builder builder = new AlertDialog.Builder(YokeActivity.this, R.style.WebviewPrompt);
+            builder.setTitle(R.string.alert_from_webview);
+            builder.setMessage(m);
+            builder.setNegativeButton(R.string.dismiss_alert, new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    dialog.cancel();
+                }
+            });
+            builder.show();
+        }
     }
 
     // https://stackoverflow.com/questions/15758856/android-how-to-download-file-from-webserver/

--- a/app/src/main/java/com/simonramstedt/yoke/YokeActivity.java
+++ b/app/src/main/java/com/simonramstedt/yoke/YokeActivity.java
@@ -617,18 +617,17 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
         popup.inflate(R.menu.overflow);
         popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
             public boolean onMenuItemClick(MenuItem item) {
-                switch (item.getItemId()) {
-                    case R.id.upgradeLayout:
-                        if (currentHost != null) {
-                            new DownloadFilesFromURL().execute(
-                                "http://" + currentHost + ":" + Integer.toString(currentPort) + "/"
-                            );
-                        } else {
-                            logInfo(res.getString(R.string.info_connected_to_nowhere));
-                        }
-                        return true;
-                    default:
-                        return false;
+                if (item.getItemId() == R.id.upgradeLayout) {
+                    if (currentHost != null) {
+                        new DownloadFilesFromURL().execute(
+                            "http://" + currentHost + ":" + Integer.toString(currentPort) + "/"
+                        );
+                    } else {
+                        logInfo(res.getString(R.string.info_connected_to_nowhere));
+                    }
+                    return true;
+                } else {
+                    return false;
                 }
             }
         });

--- a/app/src/main/java/com/simonramstedt/yoke/YokeActivity.java
+++ b/app/src/main/java/com/simonramstedt/yoke/YokeActivity.java
@@ -46,6 +46,7 @@ import java.net.SocketException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.UnknownHostException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -63,7 +64,7 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
     private NsdManager mNsdManager;
     private NsdServiceInfo mService;
     private DatagramSocket mSocket;
-    private String vals_str = null;
+    private byte[] vals_buffer = null;
     private Map<String, NsdServiceInfo> mServiceMap = new HashMap<>();
     private List<String> mServiceNames = new ArrayList<>();
     private SharedPreferences sharedPref;
@@ -142,9 +143,10 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
         }
 
         // Webpage uses this method to update joypad state:
+        // TODO: Investigate a WebMessagePort-based solution which works for Lollipop and older
         @JavascriptInterface
         public void update_vals(String vals) {
-            vals_str = vals;
+            vals_buffer = vals.getBytes(Charset.forName("ISO-8859-1"));
             update();
         }
     }
@@ -481,8 +483,8 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
     }
 
     private void update() {
-        if (mSocket != null && vals_str != null) {
-            send(vals_str.getBytes());
+        if (mSocket != null && vals_buffer != null) {
+            send(vals_buffer);
         }
     }
 
@@ -547,7 +549,7 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
             mSocket.close();
             mSocket = null;
             wv.loadUrl("about:blank");
-            vals_str = null;
+            vals_buffer = null;
             (new Thread(()-> openSocket(currentHost, currentPort))).start();
         }
     }
@@ -671,7 +673,7 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
         }
         currentHost = null;
         wv.loadUrl("about:blank");
-        vals_str = null;
+        vals_buffer = null;
     }
 }
 

--- a/app/src/main/res/layout/main_wv.xml
+++ b/app/src/main/res/layout/main_wv.xml
@@ -3,13 +3,12 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="@android:color/holo_blue_dark">
+    android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="40sp"
-        android:background="@android:color/holo_blue_light"
+        android:layout_marginRight="25dp"
         android:gravity="start"
         android:orientation="horizontal">
 
@@ -25,6 +24,7 @@
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_weight="0"
+            android:backgroundTintMode="multiply"
             android:contentDescription="@string/toolbar_reconnect"
             android:tooltipText="@string/toolbar_reconnect"
             android:onClick="reconnect" />
@@ -52,6 +52,7 @@
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_weight="0"
+            android:backgroundTintMode="multiply"
             android:contentDescription="@string/toolbar_overflow"
             android:tooltipText="@string/toolbar_overflow"
             android:onClick="showOverflowMenu" />
@@ -61,8 +62,9 @@
     <ProgressBar
         android:id="@+id/downloadProgress"
         style="@android:style/Widget.ProgressBar.Horizontal"
+        android:visibility="invisible"
         android:layout_width="match_parent"
-        android:layout_height="8dp" />
+        android:layout_height="5dp" />
 
     <WebView
         android:id="@+id/webView"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -53,6 +53,7 @@
 
     <!-- Debug messages -->
     <string name="log_adding_address">Añadiendo %1$s…</string>
+    <string name="log_closing_connection">Cerrando conexión…</string>
     <string name="log_creating_folder">Creando carpeta local %1$s</string>
     <string name="log_directly_connecting">Conectando directamente a dirección IP %1$s…</string>
     <string name="log_downloading_file">Descargando archivo a %1$s</string>
@@ -68,7 +69,8 @@
     <string name="log_service_resolve_success">Servicio «%1$s» resuelto con éxito.</string>
     <string name="log_service_resolving">Resolviendo servicio «%1$s»…</string>
     <string name="log_service_targeting">Nuevo servicio destino: «%1$s».</string>
-    <string name="log_spinner_selected">«%1$s» seleccionado en el spinner.</string>
+    <string name="log_spinner_automatic">Spinner cambiado automáticamente a "%1$s" (pos %2$d).</string>
+    <string name="log_spinner_selected">«%1$s» (pos %2$d) seleccionado en el spinner.</string>
     <string name="log_udp_closed">Conexión cerrada.</string>
 </resources>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,74 @@
+<resources>
+    <!-- Name for the app (even if it's never translated or clarified, non-latin-alphabet languages might use a phonetic transcription)
+    Apparently XML variables can only be interpolated from the Java code.
+    Until we find a comfortable way to interpolate them, the name for the app may be hardcoded in other variables. -->
+    <string name="app_name">Yoke</string>
+
+    <!-- Strings for the toolbar, displayed as soon as the app is opened -->
+    <string name="toolbar_connected_to">Conectado a</string>
+    <string name="toolbar_connect_to">Conectar a</string>
+    <!-- Buttons -->
+    <string name="toolbar_reconnect">Reconectar</string>
+    <string name="toolbar_overflow">Más opciones</string>
+
+    <!-- Overflow menu (only an item for the moment) -->
+    <string name="menu_upgrade_layout">Actualizar mando</string>
+
+    <!-- Popups shown on user mistake -->
+    <string name="info_connected_to_nowhere">Por favor, usa el menú desplegable para conectarte a una máquina.</string>
+    <string name="info_could_not_connect">No se pudo conectar a %1$s:%2$d.</string>
+    <string name="info_download_layout_first">Es necesario descargar un mando. Haz clic en el ⋮ botón menú, luego en «%1$s» y luego en ↻ «%2$s».</string>
+    <string name="info_invalid_address">Dirección inválida.</string>
+    <!-- or a toast on success: -->
+    <string name="toast_layout_succesfully_upgraded">Mando actualizado con éxito.</string>
+
+    <!-- These strings are displayed when the user opens the spinner to select a machine to connect to -->
+    <string name="dropdown_connect_to">Conectar a…</string>
+    <string name="dropdown_nothing">→ nada</string>
+    <string name="dropdown_enter_ip">→ nueva conexión manual</string>
+
+    <!-- These strings are displayed when the user chooses to specify directly IP address and port -->
+    <string name="enter_ip_title">Introduce dirección IP y puerto</string>
+    <string name="enter_ip_hint">p. ej., 192.168.1.123:11111</string>
+    <string name="enter_ip_ok">Vale</string>
+    <string name="enter_ip_cancel">Cancelar</string>
+
+    <!-- Error messages. The same string is displayed to the user than in the logcat.
+    (If they're not going to be able to fix it, better be specific) -->
+    <string name="error_discovery_failed">El descubrimiento de servicios ha fallado con código de error %1$d.</string>
+    <string name="error_open_udp_error">No se pudo abrir un socket UDP a %1$s:%2$d.</string>
+    <string name="error_could_not_create_folder">No se pudo crear la carpeta %1$s</string>
+    <string name="error_could_not_delete">No se pudo borrar %1$s</string>
+    <string name="error_could_not_rename">No se pudo renombrar %1$s</string>
+    <string name="error_io_exception">Error de lectura/escritura (IOException): %1$s.</string>
+    <string name="error_json_exception">Error interpretando manifiesto (JSONException): %1$s.</string>
+    <string name="error_connection_refused">Conexión rechazada. Comprueba si Yoke fue iniciado en tu ordenador.</string>
+    <string name="error_security_exception">Un gestor de seguridad impide a Yoke leer o escribir archivos (SecurityException).</string>
+    <string name="error_sending_security_exception">Un gestor de seguridad impide a Yoke comunicarse con tu ordenador.</string>
+    <string name="error_service_null">Servicio nulo.</string>
+    <string name="dismiss_error">Vale</string>
+    <!-- Also prompts from the webview -->
+    <string name="alert_from_webview">Mensaje de tu mando:</string>
+    <string name="dismiss_alert">Vale</string>
+
+    <!-- Debug messages -->
+    <string name="log_adding_address">Añadiendo %1$s…</string>
+    <string name="log_creating_folder">Creando carpeta local %1$s</string>
+    <string name="log_directly_connecting">Conectando directamente a dirección IP %1$s…</string>
+    <string name="log_downloading_file">Descargando archivo a %1$s</string>
+    <string name="log_discovery_started">Comenzó el descubrimiento de servicios «%1$s».</string>
+    <string name="log_discovery_stopped">Se detuvo el descubrimiento de servicios «%1$s».</string>
+    <string name="log_loading_url">Cargando desde %1$s</string>
+    <string name="log_nothing_selected">No hay nada seleccionado.</string>
+    <string name="log_open_udp_success">Conectado.</string>
+    <string name="log_opening_udp">Intentando abrir socket UDP a %1$s en el puerto %2$d…</string>
+    <string name="log_service_found">Servicio encontrado. </string>
+    <string name="log_service_lost">Servicio perdido. </string>
+    <string name="log_service_resolve_error">La resolución del servicio falló con código de error %1$d.</string>
+    <string name="log_service_resolve_success">Servicio «%1$s» resuelto con éxito.</string>
+    <string name="log_service_resolving">Resolviendo servicio «%1$s»…</string>
+    <string name="log_service_targeting">Nuevo servicio destino: «%1$s».</string>
+    <string name="log_spinner_selected">«%1$s» seleccionado en el spinner.</string>
+    <string name="log_udp_closed">Conexión cerrada.</string>
+</resources>
+

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -47,6 +47,9 @@
     <string name="error_sending_security_exception">Um Gerenciador De Segurança impede o Yoke de se comunicar com seu PC.</string>
     <string name="error_service_null">Serviço nulo.</string>
     <string name="dismiss_error">OK</string>
+    <!-- Also prompts from the webview -->
+    <string name="alert_from_webview">Mensagem do seu gamepad:</string>
+    <string name="dismiss_alert">OK</string>
 
     <!-- Debug messages -->
     <string name="log_adding_address">Adicionando %1$s…</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -14,12 +14,12 @@
     <!-- Overflow menu (only an item for the moment) -->
     <string name="menu_upgrade_layout">Icrementar gamepad</string>
 
-    <!-- Toasts shown on user mistake -->
-    <string name="toast_connected_to_nowhere">Por favor usar menu de listagem para conectar a máquina.</string>
-    <string name="toast_could_not_connect">Falha ao conectar para %1$s:%2$d.</string>
-    <string name="toast_download_layout_first">Voce precisa baixar um gamepad. Aperte o ícone ⋮ então "%1$s", depois ↻ "%2$s".</string>
-    <string name="toast_invalid_address">Endereço inválido.</string>
-    <!-- or on success: -->
+    <!-- Popups shown on user mistake -->
+    <string name="info_connected_to_nowhere">Por favor usar menu de listagem para conectar a máquina.</string>
+    <string name="info_could_not_connect">Falha ao conectar para %1$s:%2$d.</string>
+    <string name="info_download_layout_first">Voce precisa baixar um gamepad. Aperte o ícone ⋮ então "%1$s", depois ↻ "%2$s".</string>
+    <string name="info_invalid_address">Endereço inválido.</string>
+    <!-- or a toast on success: -->
     <string name="toast_layout_succesfully_upgraded">Gamepad incrementado com sucesso.</string>
 
     <!-- These strings are displayed when the user opens the spinner to select a machine to connect to -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -53,6 +53,7 @@
 
     <!-- Debug messages -->
     <string name="log_adding_address">Adicionando %1$s…</string>
+    <string name="log_closing_connection">Fechando conexão…</string>
     <string name="log_creating_folder">Criando diretório local %1$s</string>
     <string name="log_directly_connecting">Conectando diretamente para o endereço de IP %1$s…</string>
     <string name="log_downloading_file">Baixando arquivo para %1$s</string>
@@ -68,7 +69,8 @@
     <string name="log_service_resolve_success">Serviço \"%1$s\" resolvido com sucesso.</string>
     <string name="log_service_resolving">Resolvendo serviço \"%1$s\"…</string>
     <string name="log_service_targeting">Novo serviço alvo: \"%1$s\".</string>
-    <string name="log_spinner_selected">"%1$s" selecionado no girador.</string>
+    <string name="log_spinner_automatic">Girador alterado automaticamente para "%1$s" (pos %2$d).</string>
+    <string name="log_spinner_selected">"%1$s" (pos %2$d) selecionado no girador.</string>
     <string name="log_udp_closed">Conexão fechada.</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,7 +48,7 @@
     <string name="error_service_null">Service null.</string>
     <string name="dismiss_error">OK</string>
     <!-- Also prompts from the webview -->
-    <string name="alert_from_webview">Report from your gamepad:</string>
+    <string name="alert_from_webview">Message from your gamepad:</string>
     <string name="dismiss_alert">OK</string>
 
     <!-- Debug messages -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,9 @@
     <string name="error_sending_security_exception">A Security Manager is preventing Yoke from communicating with your PC.</string>
     <string name="error_service_null">Service null.</string>
     <string name="dismiss_error">OK</string>
+    <!-- Also prompts from the webview -->
+    <string name="alert_from_webview">Report from your gamepad:</string>
+    <string name="dismiss_alert">OK</string>
 
     <!-- Debug messages -->
     <string name="log_adding_address">Adding %1$s…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,12 +14,12 @@
     <!-- Overflow menu (only an item for the moment) -->
     <string name="menu_upgrade_layout">Upgrade gamepad</string>
 
-    <!-- Toasts shown on user mistake -->
-    <string name="toast_connected_to_nowhere">Please use the dropdown menu to connect to a machine.</string>
-    <string name="toast_could_not_connect">Failed to connect to %1$s:%2$d.</string>
-    <string name="toast_download_layout_first">You need to download a gamepad. Click the ⋮ menu button, then "%1$s", then ↻ "%2$s".</string>
-    <string name="toast_invalid_address">Invalid address.</string>
-    <!-- or on success: -->
+    <!-- Popups shown on user mistake -->
+    <string name="info_connected_to_nowhere">Please use the dropdown menu to connect to a machine.</string>
+    <string name="info_could_not_connect">Failed to connect to %1$s:%2$d.</string>
+    <string name="info_download_layout_first">You need to download a gamepad. Click the ⋮ menu button, then "%1$s", then ↻ "%2$s".</string>
+    <string name="info_invalid_address">Invalid address.</string>
+    <!-- or a toast on success: -->
     <string name="toast_layout_succesfully_upgraded">Gamepad succesfully upgraded.</string>
 
     <!-- These strings are displayed when the user opens the spinner to select a machine to connect to -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
 
     <!-- Debug messages -->
     <string name="log_adding_address">Adding %1$s…</string>
+    <string name="log_closing_connection">Closing connection…</string>
     <string name="log_creating_folder">Creating local folder %1$s</string>
     <string name="log_directly_connecting">Connecting directly to IP address %1$s…</string>
     <string name="log_downloading_file">Downloading file to %1$s</string>
@@ -68,7 +69,8 @@
     <string name="log_service_resolve_success">Service \"%1$s\" succesfully resolved.</string>
     <string name="log_service_resolving">Resolving service \"%1$s\"…</string>
     <string name="log_service_targeting">New service target: \"%1$s\".</string>
-    <string name="log_spinner_selected">"%1$s" selected in the spinner.</string>
+    <string name="log_spinner_automatic">Spinner set automatically to "%1$s" (pos %2$d).</string>
+    <string name="log_spinner_selected">"%1$s" (pos %2$d) selected in the spinner.</string>
     <string name="log_udp_closed">Connection closed.</string>
 </resources>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,4 +8,7 @@
         <item name="android:navigationBarColor">@android:color/black</item>
         <item name="android:progressTint">@android:color/holo_blue_bright</item>
     </style>
+    <style name="WebviewPrompt" parent="android:Theme.Material.Light.Dialog.Alert">
+        <item name="android:backgroundTint">@android:color/white</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,11 +1,11 @@
 <resources>
     <style name="YokeTheme" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:colorPrimary">@android:color/holo_blue_dark</item>
-        <item name="android:colorPrimaryDark">#ff006699</item>
-        <item name="android:colorAccent">@android:color/holo_blue_bright</item>
+        <item name="android:colorAccent">@android:color/black</item>
         <item name="android:textColorPrimary">@android:color/black</item>
-        <item name="android:windowBackground">@android:color/holo_blue_dark</item>
-        <item name="android:navigationBarColor">#00000000</item>
+        <item name="android:background">@android:color/holo_blue_light</item>
+        <item name="android:backgroundTint">@android:color/holo_blue_light</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
         <item name="android:progressTint">@android:color/holo_blue_bright</item>
     </style>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
First of all, I'm very sorry I have left with no warning for a year and a half. I've been meaning to write code for quite some time, but I have had a lot of things going on on my life lately. I'm fine and healthy, which is a lot these days. How have you been doing?

This pull request... possibly has the cleanest history I've ever written. Some context:
- The "hack to reliably pass binary data" is sending bytes as a string from JavaScript as usual, but forcing on them an old 8-bit encoding on both JavaScript and Java. It should be possible to simply send bytes[] but I wasn't able to make it work.
MessagePorts would probably be a cleaner way but that would require another rewrite of both sides, and you'd be forced to drop compatibility with Lollipop. I don't know if there is a backport for older APIs.
- I've added a function to fake an `alert()` from the WebView and remove some lines of code from the JavaScript. I'd actually like to move the touch pressure calibration as well; that way settings can persist through different gamepads and gamepad designers don't need to worry about that issue. But I haven't the slightest idea on how to do it.
- I've mentioned making styles more sane but the end result is a bit different. The good things about it is that Yoke errors are displayed in Yoke's blue and JavaScript prompts in white, so they're even easier to distinguish. On the other hand, it's a bit harsh on the eyes and I'd like some opinions before taking more drastic decisions.
- The app now downloads the manifest every time it connects to a webserver. It's a guarantee you're actually connecting to your webserver on your wifi once you know about it (and it reminds me to actually enable wi-fi on my phone) but it needs a better way to detect timeouts.
- There are a couple of bugs I haven't been able to properly isolate or fix yet (for example, the app usually fails to make a connection the first time you use the spinner after launching it).