### PR TITLE
Improve error handling and warn before disconnecting

### DIFF
--- a/app/src/main/java/com/simonramstedt/yoke/YokeActivity.java
+++ b/app/src/main/java/com/simonramstedt/yoke/YokeActivity.java
@@ -723,7 +723,7 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
         log(res.getString(R.string.log_closing_connection));
         // Don't update the last status report:
         wv.loadUrl("about:blank");
-        if (mSocket != null && warn) {
+        if (mSocket != null && vals_buffer != null && warn) {
             byte[] impending_disconnect = new byte[vals_buffer.length];
             // Disable auto-update to avoid race conditions:
             vals_buffer = null;

--- a/app/src/main/java/com/simonramstedt/yoke/YokeActivity.java
+++ b/app/src/main/java/com/simonramstedt/yoke/YokeActivity.java
@@ -212,7 +212,7 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
                 logError(res.getString(R.string.error_security_exception), e);
                 cancel(true);
             } catch (IOException e) {
-                logError(e.getLocalizedMessage(), e);
+                logError(e.getMessage(), e);
                 cancel(true);
             }
         }
@@ -283,10 +283,14 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
                     return PING_SUCCESS;
                 }
             } catch (IOException e) {
-                if (e.getLocalizedMessage().contains(" ECONNREFUSED ")) {
+                if (e.getMessage().contains(" ECONNREFUSED ")) {
                     logError(res.getString(R.string.error_connection_refused), e);
+                } else if (e.getMessage().contains(" ENETUNREACH ")) {
+                    logError(res.getString(R.string.error_network_unreachable), e);
+                } else if (e.getMessage().startsWith("Failed to connect to")) {
+                    logError(res.getString(R.string.error_failed_download), e);
                 } else {
-                    logError(e.getLocalizedMessage(), e);
+                    logError(e.getMessage(), e);
                 }
                 cancel(true);
             } catch (JSONException e) {
@@ -552,10 +556,12 @@ public class YokeActivity extends Activity implements NsdManager.DiscoveryListen
             logError(res.getString(R.string.error_sending_security_exception), e);
             closeConnection();
         } catch (IOException e) {
-            if (e.getLocalizedMessage().contains(" ECONNREFUSED ")) {
-                logError(res.getString(R.string.error_connection_refused), e);
+            if (e.getMessage().contains(" ECONNREFUSED ")) {
+                logError(res.getString(R.string.error_pc_client_closed), e);
+            } else if (e.getMessage().contains(" ENETUNREACH ")) {
+                logError(res.getString(R.string.error_network_unreachable), e);
             } else {
-                logError(e.getLocalizedMessage(), e);
+                logError(e.getMessage(), e);
             }
             closeConnection();
         }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -74,5 +74,6 @@
     <string name="log_spinner_automatic">Spinner cambiado automáticamente a "%1$s" (pos %2$d).</string>
     <string name="log_spinner_selected">«%1$s» (pos %2$d) seleccionado en el spinner.</string>
     <string name="log_udp_closed">Conexión cerrada.</string>
+    <string name="log_warning_shot">Enviada la señal de desconexión.</string>
 </resources>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -16,7 +16,6 @@
 
     <!-- Popups shown on user mistake -->
     <string name="info_connected_to_nowhere">Por favor, usa el menú desplegable para conectarte a una máquina.</string>
-    <string name="info_could_not_connect">No se pudo conectar a %1$s:%2$d.</string>
     <string name="info_download_layout_first">Es necesario descargar un mando. Haz clic en el ⋮ botón menú, luego en «%1$s» y luego en ↻ «%2$s».</string>
     <string name="info_invalid_address">Dirección inválida.</string>
     <!-- or a toast on success: -->
@@ -42,7 +41,10 @@
     <string name="error_could_not_rename">No se pudo renombrar %1$s</string>
     <string name="error_io_exception">Error de lectura/escritura (IOException): %1$s.</string>
     <string name="error_json_exception">Error interpretando manifiesto (JSONException): %1$s.</string>
-    <string name="error_connection_refused">Conexión rechazada. Comprueba si Yoke fue iniciado en tu ordenador.</string>
+    <string name="error_failed_download">No se encontró el servidor web. Por favor, comprueba si Yoke fue iniciado en tu ordenador.</string>
+    <string name="error_connection_refused">Conexión rechazada. Por favor, comprueba si Yoke fue iniciado en tu ordenador.</string>
+    <string name="error_pc_client_closed">El cliente Yoke para PC se ha detenido. Puedes ver más información en tu ordenador.</string>
+    <string name="error_network_unreachable">No hay conexión a internet. Comprueba que este dispositivo está conectado a tu red.</string>
     <string name="error_security_exception">Un gestor de seguridad impide a Yoke leer o escribir archivos (SecurityException).</string>
     <string name="error_sending_security_exception">Un gestor de seguridad impide a Yoke comunicarse con tu ordenador.</string>
     <string name="error_service_null">Servicio nulo.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -16,7 +16,6 @@
 
     <!-- Popups shown on user mistake -->
     <string name="info_connected_to_nowhere">Por favor usar menu de listagem para conectar a máquina.</string>
-    <string name="info_could_not_connect">Falha ao conectar para %1$s:%2$d.</string>
     <string name="info_download_layout_first">Voce precisa baixar um gamepad. Aperte o ícone ⋮ então "%1$s", depois ↻ "%2$s".</string>
     <string name="info_invalid_address">Endereço inválido.</string>
     <!-- or a toast on success: -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,5 +75,6 @@
     <string name="log_spinner_automatic">Spinner set automatically to "%1$s" (pos %2$d).</string>
     <string name="log_spinner_selected">"%1$s" (pos %2$d) selected in the spinner.</string>
     <string name="log_udp_closed">Connection closed.</string>
+    <string name="log_warning_shot">Sent disconnect signal.</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,6 @@
 
     <!-- Popups shown on user mistake -->
     <string name="info_connected_to_nowhere">Please use the dropdown menu to connect to a machine.</string>
-    <string name="info_could_not_connect">Failed to connect to %1$s:%2$d.</string>
     <string name="info_download_layout_first">You need to download a gamepad. Click the ⋮ menu button, then "%1$s", then ↻ "%2$s".</string>
     <string name="info_invalid_address">Invalid address.</string>
     <!-- or a toast on success: -->
@@ -37,12 +36,16 @@
     (If they're not going to be able to fix it, better be specific) -->
     <string name="error_discovery_failed">Service discovery failed with error code %1$d.</string>
     <string name="error_open_udp_error">Failed to open UDP socket to %1$s:%2$d.</string>
+    <string name="error_could_not_connect">Failed to connect to %1$s</string>
     <string name="error_could_not_create_folder">Could not create folder %1$s</string>
     <string name="error_could_not_delete">Could not delete %1$s</string>
     <string name="error_could_not_rename">Could not rename %1$s</string>
     <string name="error_io_exception">Read/write error (IOException): %1$s.</string>
     <string name="error_json_exception">Error parsing manifest (JSONException): %1$s.</string>
-    <string name="error_connection_refused">Connection refused. Check if Yoke is running on your PC.</string>
+    <string name="error_failed_download">Webserver not found. Please check if Yoke is running on your PC.</string>
+    <string name="error_connection_refused">Connection refused. Please check if Yoke is running on your PC.</string>
+    <string name="error_pc_client_closed">The Yoke client for PC has stopped. You can check your PC screen for more information.</string>
+    <string name="error_network_unreachable">No Internet connection. Please make sure this device is connected to your network.</string>
     <string name="error_security_exception">A Security Manager is preventing Yoke from reading or writing files (SecurityException).</string>
     <string name="error_sending_security_exception">A Security Manager is preventing Yoke from communicating with your PC.</string>
     <string name="error_service_null">Service null.</string>


### PR DESCRIPTION
The two first commits should be self-explanatory. The last one... you can guess.

Besides making Yoke a bit more pleasant and easier to use, this also simplifies the work of `service.py`. If devices are forbidden from changing while they're connected, the PC doesn't have to check that as often, and the main loop can be kept more tight.

To that end, some collaboration from the app is necessary. The app will send three rows of 0xFF bytes, exactly as long as the last status report, before a deliberate disconnection.

Also, one of our error messages in English is a bit more polite now.